### PR TITLE
Document removal of GPL third-party assets

### DIFF
--- a/source/resources/AssetOrigins.gd
+++ b/source/resources/AssetOrigins.gd
@@ -19,7 +19,8 @@ const ORIGINS := {
 			]
 		)
 	},
-	"Meshy Godot Plugin": {
+	"Meshy Godot Plugin":
+	{
 		"repository": "https://github.com/meshy-dev/meshy-godot-plugin",
 		"asset_roots": PackedStringArray(["res://addons/meshy"])
 	}

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,5 @@
+# Third-party Assets
+
+This directory only contains third-party content that is compatible with the project's MIT license.
+
+The GPL-licensed **lo-th 3d.city** package has been purged from the repository and must not be reintroduced. Keeping GPLv3-licensed assets alongside the MIT codebase would obligate the entire project to adopt the GPL, so ensure any future additions here are reviewed for license compatibility.


### PR DESCRIPTION
## Summary
- add documentation in `third_party/README.md` noting the removal of the GPL-licensed lo-th 3d.city package
- clarify that only license-compatible third-party assets should live in this directory

## Testing
- not run